### PR TITLE
feat: Add heating/cooling duration statistics

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -48,6 +48,40 @@ def get_statistics():
         func.max(TemperatureReading.outside_temperature_c).label('max_outside_temp')
     ).filter(TemperatureReading.timestamp >= since).first()
     
+    # Calculate heating and cooling durations
+    readings = TemperatureReading.query.filter(
+        TemperatureReading.timestamp >= since
+    ).order_by(TemperatureReading.timestamp).all()
+    
+    heating_duration = timedelta()
+    cooling_duration = timedelta()
+    
+    for i in range(len(readings) - 1):
+        current_reading = readings[i]
+        next_reading = readings[i + 1]
+        time_diff = next_reading.timestamp - current_reading.timestamp
+        
+        if current_reading.hvac_state == 'HEATING':
+            heating_duration += time_diff
+        elif current_reading.hvac_state == 'COOLING':
+            cooling_duration += time_diff
+    
+    # Handle the last reading (assume it continues until now)
+    if readings and len(readings) > 0:
+        last_reading = readings[-1]
+        time_diff = datetime.utcnow() - last_reading.timestamp
+        
+        if last_reading.hvac_state == 'HEATING':
+            heating_duration += time_diff
+        elif last_reading.hvac_state == 'COOLING':
+            cooling_duration += time_diff
+    
+    # Convert durations to hours and minutes
+    heating_hours = int(heating_duration.total_seconds() // 3600)
+    heating_minutes = int((heating_duration.total_seconds() % 3600) // 60)
+    cooling_hours = int(cooling_duration.total_seconds() // 3600)
+    cooling_minutes = int((cooling_duration.total_seconds() % 3600) // 60)
+    
     return jsonify({
         'avg_temperature': round(stats.avg_temp, 1) if stats.avg_temp else None,
         'min_temperature': round(stats.min_temp, 1) if stats.min_temp else None,
@@ -56,6 +90,10 @@ def get_statistics():
         'avg_outside_temperature': round(stats.avg_outside_temp, 1) if stats.avg_outside_temp else None,
         'min_outside_temperature': round(stats.min_outside_temp, 1) if stats.min_outside_temp else None,
         'max_outside_temperature': round(stats.max_outside_temp, 1) if stats.max_outside_temp else None,
+        'heating_duration_hours': heating_hours,
+        'heating_duration_minutes': heating_minutes,
+        'cooling_duration_hours': cooling_hours,
+        'cooling_duration_minutes': cooling_minutes,
         'period_hours': hours
     })
 

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -55,6 +55,17 @@ async function loadStatistics(hours) {
       data.max_outside_temperature
         ? `${Math.round(data.max_outside_temperature * 2) / 2}°C`
         : "--°C";
+    
+    // Display heating and cooling durations
+    const heatingDuration = data.heating_duration_hours !== undefined
+      ? `${data.heating_duration_hours}h ${data.heating_duration_minutes}m`
+      : "--";
+    const coolingDuration = data.cooling_duration_hours !== undefined
+      ? `${data.cooling_duration_hours}h ${data.cooling_duration_minutes}m`
+      : "--";
+    
+    document.getElementById("heating-duration").textContent = heatingDuration;
+    document.getElementById("cooling-duration").textContent = coolingDuration;
   } catch (error) {
     console.error("Error loading statistics:", error);
   }

--- a/templates/index.html
+++ b/templates/index.html
@@ -78,6 +78,14 @@
                     <span class="stat-label">Max Outside:</span>
                     <span class="stat-data" id="max-outside-temp">--°C</span>
                 </div>
+                <div class="stat-item">
+                    <span class="stat-label">Heating Time:</span>
+                    <span class="stat-data" id="heating-duration">--</span>
+                </div>
+                <div class="stat-item">
+                    <span class="stat-label">Cooling Time:</span>
+                    <span class="stat-data" id="cooling-duration">--</span>
+                </div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Fixes #3

## Summary
Added heating and cooling duration statistics to the temperature monitor application.

## Changes
- Enhanced the `/api/statistics` endpoint to calculate total time spent in HEATING and COOLING states
- Added "Heating Time" and "Cooling Time" display items to the statistics section
- Updated JavaScript to format and display durations as "Xh Ym"

Generated with [Claude Code](https://claude.ai/code)