### PR TITLE
feat: Add outside humidity to the graph

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -14,6 +14,7 @@ class TemperatureReading(db.Model):
     hvac_state = db.Column(db.String(50))
     outside_temperature_c = db.Column(db.Float)
     outside_temperature_f = db.Column(db.Float)
+    outside_humidity = db.Column(db.Float)
     
     def to_dict(self):
         return {
@@ -28,5 +29,6 @@ class TemperatureReading(db.Model):
             'hvac_mode': self.hvac_mode,
             'hvac_state': self.hvac_state,
             'outside_temperature_c': self.outside_temperature_c,
-            'outside_temperature_f': self.outside_temperature_f
+            'outside_temperature_f': self.outside_temperature_f,
+            'outside_humidity': self.outside_humidity
         }

--- a/app/nest_client.py
+++ b/app/nest_client.py
@@ -95,11 +95,14 @@ def collect_temperature_data():
         weather_data = weather_client.get_current_weather()
         outside_temp_c = None
         outside_temp_f = None
+        outside_humidity = None
         
         if weather_data:
             outside_temp_c = weather_data['temperature_c']
             outside_temp_f = weather_data['temperature_f']
+            outside_humidity = weather_data['humidity']
             print(f"Outside temperature: {outside_temp_c}°C / {outside_temp_f}°F")
+            print(f"Outside humidity: {outside_humidity}%")
         else:
             print("Could not fetch weather data")
         
@@ -130,7 +133,8 @@ def collect_temperature_data():
                         hvac_mode=hvac_data.get('mode'),
                         hvac_state=hvac_data.get('status'),
                         outside_temperature_c=outside_temp_c,
-                        outside_temperature_f=outside_temp_f
+                        outside_temperature_f=outside_temp_f,
+                        outside_humidity=outside_humidity
                     )
                     
                     db.session.add(reading)

--- a/app/routes.py
+++ b/app/routes.py
@@ -45,7 +45,10 @@ def get_statistics():
         func.avg(TemperatureReading.humidity).label('avg_humidity'),
         func.avg(TemperatureReading.outside_temperature_c).label('avg_outside_temp'),
         func.min(TemperatureReading.outside_temperature_c).label('min_outside_temp'),
-        func.max(TemperatureReading.outside_temperature_c).label('max_outside_temp')
+        func.max(TemperatureReading.outside_temperature_c).label('max_outside_temp'),
+        func.avg(TemperatureReading.outside_humidity).label('avg_outside_humidity'),
+        func.min(TemperatureReading.outside_humidity).label('min_outside_humidity'),
+        func.max(TemperatureReading.outside_humidity).label('max_outside_humidity')
     ).filter(TemperatureReading.timestamp >= since).first()
     
     # Calculate heating and cooling durations
@@ -90,6 +93,9 @@ def get_statistics():
         'avg_outside_temperature': round(stats.avg_outside_temp, 1) if stats.avg_outside_temp else None,
         'min_outside_temperature': round(stats.min_outside_temp, 1) if stats.min_outside_temp else None,
         'max_outside_temperature': round(stats.max_outside_temp, 1) if stats.max_outside_temp else None,
+        'avg_outside_humidity': round(stats.avg_outside_humidity, 1) if stats.avg_outside_humidity else None,
+        'min_outside_humidity': round(stats.min_outside_humidity, 1) if stats.min_outside_humidity else None,
+        'max_outside_humidity': round(stats.max_outside_humidity, 1) if stats.max_outside_humidity else None,
         'heating_duration_hours': heating_hours,
         'heating_duration_minutes': heating_minutes,
         'cooling_duration_hours': cooling_hours,

--- a/migrations/add_outside_humidity.py
+++ b/migrations/add_outside_humidity.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+"""Add outside humidity column to temperature readings table."""
+
+import os
+import sys
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from app import create_app, db
+from sqlalchemy import text
+
+def migrate():
+    app = create_app()
+    
+    with app.app_context():
+        # Check if column already exists
+        result = db.session.execute(text("PRAGMA table_info(temperature_reading)"))
+        columns = [row[1] for row in result]
+        
+        if 'outside_humidity' not in columns:
+            # Add the outside_humidity column
+            db.session.execute(text(
+                "ALTER TABLE temperature_reading ADD COLUMN outside_humidity FLOAT"
+            ))
+            db.session.commit()
+            print("Successfully added outside_humidity column")
+        else:
+            print("outside_humidity column already exists")
+
+if __name__ == '__main__':
+    migrate()

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -21,6 +21,9 @@ async function loadCurrent() {
       data.outside_temperature_c
         ? `${Math.round(data.outside_temperature_c * 2) / 2}°C`
         : "--°C";
+    document.getElementById("outside-humidity").textContent = data.outside_humidity
+      ? `${Math.round(data.outside_humidity)}%`
+      : "--%";
   } catch (error) {
     console.error("Error loading current data:", error);
   }
@@ -55,6 +58,18 @@ async function loadStatistics(hours) {
       data.max_outside_temperature
         ? `${Math.round(data.max_outside_temperature * 2) / 2}°C`
         : "--°C";
+    document.getElementById("avg-outside-humidity").textContent =
+      data.avg_outside_humidity
+        ? `${Math.round(data.avg_outside_humidity)}%`
+        : "--%";
+    document.getElementById("min-outside-humidity").textContent =
+      data.min_outside_humidity
+        ? `${Math.round(data.min_outside_humidity)}%`
+        : "--%";
+    document.getElementById("max-outside-humidity").textContent =
+      data.max_outside_humidity
+        ? `${Math.round(data.max_outside_humidity)}%`
+        : "--%";
     
     // Display heating and cooling durations
     const heatingDuration = data.heating_duration_hours !== undefined
@@ -225,6 +240,15 @@ function updateChart(data) {
         data: data.map((d) => d.humidity),
         borderColor: "#2ecc71",
         backgroundColor: "rgba(46, 204, 113, 0.1)",
+        tension: 0.4,
+        yAxisID: "y-humidity",
+      },
+      {
+        label: "Outside Humidity (%)",
+        data: data.map((d) => d.outside_humidity),
+        borderColor: "#f39c12",
+        backgroundColor: "rgba(243, 156, 18, 0.1)",
+        borderDash: [3, 3],
         tension: 0.4,
         yAxisID: "y-humidity",
       },

--- a/templates/index.html
+++ b/templates/index.html
@@ -33,6 +33,10 @@
                 <h3>Outside Temperature</h3>
                 <div class="stat-value" id="outside-temp">--°C</div>
             </div>
+            <div class="stat-card">
+                <h3>Outside Humidity</h3>
+                <div class="stat-value" id="outside-humidity">--%</div>
+            </div>
         </div>
         
         <div class="time-selector">
@@ -77,6 +81,18 @@
                 <div class="stat-item">
                     <span class="stat-label">Max Outside:</span>
                     <span class="stat-data" id="max-outside-temp">--°C</span>
+                </div>
+                <div class="stat-item">
+                    <span class="stat-label">Avg Outside Humidity:</span>
+                    <span class="stat-data" id="avg-outside-humidity">--%</span>
+                </div>
+                <div class="stat-item">
+                    <span class="stat-label">Min Outside Humidity:</span>
+                    <span class="stat-data" id="min-outside-humidity">--%</span>
+                </div>
+                <div class="stat-item">
+                    <span class="stat-label">Max Outside Humidity:</span>
+                    <span class="stat-data" id="max-outside-humidity">--%</span>
                 </div>
                 <div class="stat-item">
                     <span class="stat-label">Heating Time:</span>


### PR DESCRIPTION
- Create database migration for outside_humidity column
- Update models to include outside_humidity field
- Modify data collection to fetch and store humidity from weather API
- Add outside humidity statistics to API endpoints
- Display outside humidity in current stats and statistics sections
- Add outside humidity dataset to graph (orange dashed line)

Fixes #5